### PR TITLE
Bump spring.version in /onlineshopping

### DIFF
--- a/onlineshopping/pom.xml
+++ b/onlineshopping/pom.xml
@@ -11,7 +11,7 @@
 	<!-- Version information will be stored here -->
 	<properties>
 		<javaee.version>7.0</javaee.version>
-		<spring.version>4.3.6.RELEASE</spring.version>
+		<spring.version>5.2.5.RELEASE</spring.version>
 		<spring.security.version>4.2.2.RELEASE</spring.security.version>
 		
 	</properties>


### PR DESCRIPTION
Bumps `spring.version` from 4.3.6.RELEASE to 5.2.5.RELEASE.

Updates `spring-core` from 4.3.6.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.3.6.RELEASE...v5.2.5.RELEASE)

Updates `spring-webmvc` from 4.3.6.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.3.6.RELEASE...v5.2.5.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>