### PR TITLE
Bump spring.version in /shoppingbackend

### DIFF
--- a/shoppingbackend/pom.xml
+++ b/shoppingbackend/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring.version>4.3.6.RELEASE</spring.version>
+		<spring.version>5.2.5.RELEASE</spring.version>
 		<hibernate.version>5.2.7.Final</hibernate.version>
 		<jackson.version>2.10.3</jackson.version>
 		<mysql.version>8.0.19</mysql.version>


### PR DESCRIPTION
Bumps `spring.version` from 4.3.6.RELEASE to 5.2.5.RELEASE.

Updates `spring-core` from 4.3.6.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.3.6.RELEASE...v5.2.5.RELEASE)

Updates `spring-context` from 4.3.6.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.3.6.RELEASE...v5.2.5.RELEASE)

Updates `spring-web` from 4.3.6.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.3.6.RELEASE...v5.2.5.RELEASE)

Updates `spring-orm` from 4.3.6.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v4.3.6.RELEASE...v5.2.5.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>